### PR TITLE
feat: customizable data regimes for training set

### DIFF
--- a/data/dataset.py
+++ b/data/dataset.py
@@ -19,8 +19,8 @@ class GeneralizedClassificationDataset(torch.utils.data.Dataset):
         else:
             raise ValueError("classes input is neither a comma-separated string nor a tuple")
         self.class_to_idx = {class_name: idx for idx, class_name in enumerate(self.class_names)}
-
-        if self.data_regime < 1.0:
+        
+        if not self.data_regime == 1.0:
             self._apply_data_regime()
 
     def __len__(self):
@@ -37,6 +37,8 @@ class GeneralizedClassificationDataset(torch.utils.data.Dataset):
         return {"image": image, "label": label}
 
     def _apply_data_regime(self):
+        if self.data_regime > 1.0 or self.data_regime <= 0.0:
+            raise ValueError("data_regime must be in range (0, 1]")
         num_samples = int(len(self.dataset) * self.data_regime)
         indices = np.random.choice(len(self.dataset), num_samples, replace=False)
         self.dataset = self.dataset.iloc[indices].reset_index(drop=True)

--- a/main.py
+++ b/main.py
@@ -38,6 +38,7 @@ def train(
         oversample_col = 'label',#TODO ~ Customize (eligible: 'label', 'fitz')
         downsample_factor=1.0, #TODO ~ Customize (determines the percentage of image quality)
         oversample_factor=1.0, #TODO ~ Customize (determines the oversampling factor, magnitude 1 indicates a balanced set, >1 increases minority class sapmples)
+        data_regime=1.0, #TODO ~ Customize (determines the percentage of training data to use)
         ## model params
         
         vit_model="eva_clip_g",

--- a/skingpt4/classification/classification_task.py
+++ b/skingpt4/classification/classification_task.py
@@ -24,6 +24,7 @@ class ClassificationTask(pl.LightningModule, TFLogger):
         self.oversample_factor = self.hparams.get('oversample_factor', 1.0) 
         self.oversample_col = self.hparams.get('oversample_col', 'label')
         self.downsample_factor = self.hparams.get('downsample_factor', 0.5)
+        self.data_regime = self.hparams.get('data_regime', 1.0)
         self.dataset_path = self.hparams.get('dataset_path', "")
         self.classes = self.hparams.get('classes', ('Eczema', 'Allergic Contact Dermatitis','Urticaria', 'Psoriasis', 'Impetigo', 'Tinea'))
         
@@ -91,7 +92,12 @@ class ClassificationTask(pl.LightningModule, TFLogger):
         transformer.to_tensor()
         transformer.randomize_img(degree=1)
         transforms = transformer.get_transforms()
-        dataset = GeneralizedClassificationDataset(dataset_path=self.dataset_path, split="train", transforms=transforms, classes=self.classes)
+        dataset = GeneralizedClassificationDataset(
+            dataset_path=self.dataset_path, split="train", 
+            transforms=transforms, 
+            classes=self.classes, 
+            data_regime=self.data_regime
+        )
         if self.oversample:
             labels = dataset.dataset[self.oversample_col].tolist()
             class_counts = {cls: labels.count(cls) for cls in set(labels)}
@@ -110,7 +116,12 @@ class ClassificationTask(pl.LightningModule, TFLogger):
         transformer = Transformer()
         transformer.to_tensor()
         transforms = transformer.get_transforms()
-        dataset = GeneralizedClassificationDataset(dataset_path=self.dataset_path, split="val", transforms=transforms, classes=self.classes)
+        dataset = GeneralizedClassificationDataset(
+            dataset_path=self.dataset_path, split="val", 
+            transforms=transforms, 
+            classes=self.classes,
+            data_regime=self.data_regime
+        )
         print(f"Validation set number of samples: {len(dataset)}")
         return DataLoader(dataset, shuffle=False,
                           batch_size=1, num_workers=8)
@@ -119,7 +130,13 @@ class ClassificationTask(pl.LightningModule, TFLogger):
         transformer = Transformer()
         transformer.to_tensor()
         transforms = transformer.get_transforms()
-        dataset = GeneralizedClassificationDataset(dataset_path=self.dataset_path, split="test", transforms=transforms, classes=self.classes)
+        dataset = GeneralizedClassificationDataset(
+            dataset_path=self.dataset_path, 
+            split="test", 
+            transforms=transforms, 
+            classes=self.classes,
+            data_regime = self.data_regime
+        )
         print(f"Testing set number of samples: {len(dataset)}")
         return DataLoader(dataset, shuffle=False,
                           batch_size=1, num_workers=8)

--- a/skingpt4/classification/classification_task.py
+++ b/skingpt4/classification/classification_task.py
@@ -19,7 +19,14 @@ class ClassificationTask(pl.LightningModule, TFLogger):
         self.loss = get_loss_fn(params)
         self.evaluator = GeneralClassificationEvaluator()
         self.validation_outputs=[]
-
+        self.lr = self.hparams.get('learning_rate', 5e-4)
+        self.oversample = self.hparams.get('oversample', False)
+        self.oversample_factor = self.hparams.get('oversample_factor', 1.0) 
+        self.oversample_col = self.hparams.get('oversample_col', 'label')
+        self.downsample_factor = self.hparams.get('downsample_factor', 0.5)
+        self.dataset_path = self.hparams.get('dataset_path', "")
+        self.classes = self.hparams.get('classes', ('Eczema', 'Allergic Contact Dermatitis','Urticaria', 'Psoriasis', 'Impetigo', 'Tinea'))
+        
     def forward(self, x):
         return self.model(x)
 
@@ -75,25 +82,20 @@ class ClassificationTask(pl.LightningModule, TFLogger):
         return self.on_validation_epoch_end()
 
     def configure_optimizers(self):
-        lr = self.hparams.get('learning_rate', 5e-4)
-        return torch.optim.Adam(self.parameters(), lr=lr)
+        return torch.optim.Adam(self.parameters(), lr=self.lr)
     
     def train_dataloader(self):
-        oversample = self.hparams.get('oversample', False)
-        dataset_path = self.hparams.get('dataset_path', "")
-        oversample_factor = self.hparams.get('oversample_factor', 1.0) 
-        downsample_factor = self.hparams.get('downsample_factor', 0.5)
+
         transformer = Transformer()
-        transformer.downsample(downsample_factor)
+        transformer.downsample(self.downsample_factor)
         transformer.to_tensor()
         transformer.randomize_img(degree=1)
         transforms = transformer.get_transforms()
-        dataset = GeneralizedClassificationDataset(dataset_path=dataset_path, split="train", transforms=transforms, classes=self.hparams.get('classes'))
-        if oversample:
-            oversample_col = self.hparams.get('oversample_col', 'label')
-            labels = dataset.dataset[oversample_col].tolist()
+        dataset = GeneralizedClassificationDataset(dataset_path=self.dataset_path, split="train", transforms=transforms, classes=self.classes)
+        if self.oversample:
+            labels = dataset.dataset[self.oversample_col].tolist()
             class_counts = {cls: labels.count(cls) for cls in set(labels)}
-            class_weights = {cls: (1.0 / count)*oversample_factor for cls, count in class_counts.items()}
+            class_weights = {cls: (1.0 / count)*self.oversample_factor for cls, count in class_counts.items()}
             sample_weights = [class_weights[label] for label in labels]
             sampler = WeightedRandomSampler(sample_weights, len(sample_weights))
             shuffle=False
@@ -105,21 +107,19 @@ class ClassificationTask(pl.LightningModule, TFLogger):
                           batch_size=2, num_workers=8)
  
     def val_dataloader(self):
-        dataset_path = self.hparams.get('dataset_path', "")
         transformer = Transformer()
         transformer.to_tensor()
         transforms = transformer.get_transforms()
-        dataset = GeneralizedClassificationDataset(dataset_path=dataset_path, split="val", transforms=transforms, classes=self.hparams.get('classes'))
+        dataset = GeneralizedClassificationDataset(dataset_path=self.dataset_path, split="val", transforms=transforms, classes=self.classes)
         print(f"Validation set number of samples: {len(dataset)}")
         return DataLoader(dataset, shuffle=False,
                           batch_size=1, num_workers=8)
 
     def test_dataloader(self):
-        dataset_path = self.hparams.get('dataset_path', "")
         transformer = Transformer()
         transformer.to_tensor()
         transforms = transformer.get_transforms()
-        dataset = GeneralizedClassificationDataset(dataset_path=dataset_path, split="test", transforms=transforms, classes=self.hparams.get('classes'))
+        dataset = GeneralizedClassificationDataset(dataset_path=self.dataset_path, split="test", transforms=transforms, classes=self.classes)
         print(f"Testing set number of samples: {len(dataset)}")
         return DataLoader(dataset, shuffle=False,
                           batch_size=1, num_workers=8)

--- a/skingpt4/classification/classification_task.py
+++ b/skingpt4/classification/classification_task.py
@@ -120,7 +120,6 @@ class ClassificationTask(pl.LightningModule, TFLogger):
             dataset_path=self.dataset_path, split="val", 
             transforms=transforms, 
             classes=self.classes,
-            data_regime=self.data_regime
         )
         print(f"Validation set number of samples: {len(dataset)}")
         return DataLoader(dataset, shuffle=False,
@@ -135,7 +134,6 @@ class ClassificationTask(pl.LightningModule, TFLogger):
             split="test", 
             transforms=transforms, 
             classes=self.classes,
-            data_regime = self.data_regime
         )
         print(f"Testing set number of samples: {len(dataset)}")
         return DataLoader(dataset, shuffle=False,


### PR DESCRIPTION
Support for new training param, `data_regime`, a float between (0, 1] that defines the proportion of the training set we will use in training. Random samples from the training set

**Test / example usage**
`python main.py train --dataset_path="..." --num_classes=2 --classes='Eczema,Psoriasis' --data_regime=0.5 --exp_name=data_regime_test`
-> Instead of full training set size (184 entries), train data loader will only load 0.5*184 = 92 entries by random sample
