### PR TITLE
fix: auroc metric computes properly for all confidence subsets

### DIFF
--- a/data/dataset.py
+++ b/data/dataset.py
@@ -20,8 +20,8 @@ class GeneralizedClassificationDataset(torch.utils.data.Dataset):
             raise ValueError("classes input is neither a comma-separated string nor a tuple")
         self.class_to_idx = {class_name: idx for idx, class_name in enumerate(self.class_names)}
         
-        #if not self.data_regime == 1.0:
-            #self._apply_data_regime()
+        if not self.data_regime == 1.0:
+            self._apply_data_regime()
 
     def __len__(self):
         return len(self.dataset) 

--- a/data/dataset.py
+++ b/data/dataset.py
@@ -20,8 +20,8 @@ class GeneralizedClassificationDataset(torch.utils.data.Dataset):
             raise ValueError("classes input is neither a comma-separated string nor a tuple")
         self.class_to_idx = {class_name: idx for idx, class_name in enumerate(self.class_names)}
         
-        if not self.data_regime == 1.0:
-            self._apply_data_regime()
+        #if not self.data_regime == 1.0:
+            #self._apply_data_regime()
 
     def __len__(self):
         return len(self.dataset) 

--- a/main.py
+++ b/main.py
@@ -24,6 +24,7 @@ def train(
         patience=20,
         gradient_clip_val=0.5,
         limit_train_batches=16.0, #TODO ~ Customize
+        val_batches=1.0, #TODO ~ Customize
         weights_summary=None,
         max_epochs=200,
 

--- a/main.py
+++ b/main.py
@@ -24,7 +24,7 @@ def train(
         patience=20,
         gradient_clip_val=0.5,
         limit_train_batches=16.0, #TODO ~ Customize
-        val_batches=1.0, #TODO ~ Customize
+        val_batches=8, #TODO ~ Customize
         weights_summary=None,
         max_epochs=200,
 

--- a/skingpt4/classification/classification_task.py
+++ b/skingpt4/classification/classification_task.py
@@ -111,7 +111,7 @@ class ClassificationTask(pl.LightningModule, TFLogger):
             shuffle = True
         print(f"Training set number of samples: {len(dataset)}")
         return DataLoader(dataset, shuffle=shuffle, sampler=sampler,
-                          batch_size=16, num_workers=8)
+                          batch_size=32, num_workers=8)
  
     def val_dataloader(self):
         transformer = Transformer()

--- a/skingpt4/classification/classification_task.py
+++ b/skingpt4/classification/classification_task.py
@@ -125,7 +125,7 @@ class ClassificationTask(pl.LightningModule, TFLogger):
         )
         print(f"Validation set number of samples: {len(dataset)}")
         return DataLoader(dataset, shuffle=False,
-                          batch_size=1, num_workers=8)
+                          batch_size=8, num_workers=8)
 
     def test_dataloader(self):
         transformer = Transformer()

--- a/skingpt4/classification/classification_task.py
+++ b/skingpt4/classification/classification_task.py
@@ -23,7 +23,7 @@ class ClassificationTask(pl.LightningModule, TFLogger):
         self.oversample = self.hparams.get('oversample', False)
         self.oversample_factor = self.hparams.get('oversample_factor', 1.0) 
         self.oversample_col = self.hparams.get('oversample_col', 'label')
-        self.downsample_factor = self.hparams.get('downsample_factor', 0.5)
+        self.downsample_factor = self.hparams.get('downsample_factor', 1.0)
         self.data_regime = self.hparams.get('data_regime', 1.0)
         self.dataset_path = self.hparams.get('dataset_path', "")
         self.classes = self.hparams.get('classes', ('Eczema', 'Allergic Contact Dermatitis','Urticaria', 'Psoriasis', 'Impetigo', 'Tinea'))
@@ -53,6 +53,8 @@ class ClassificationTask(pl.LightningModule, TFLogger):
         y_hat = (logits > 0).float()
         self.evaluator.update((logits, y))
         self.validation_outputs.append(loss)
+        print(f"Validation step batch: {batch}")
+        print(f"Val labels: {y}")
         return {'loss': loss}
 
     def on_validation_epoch_end(self):

--- a/skingpt4/classification/classification_task.py
+++ b/skingpt4/classification/classification_task.py
@@ -108,11 +108,6 @@ class ClassificationTask(pl.LightningModule, TFLogger):
         else:
             sampler = None
             shuffle = True
-
-        class_counts_after_oversampling = {cls: 0 for cls in set(labels)}
-        for idx in sampler:
-            class_counts_after_oversampling[labels[idx]] += 1
-        print(f"Class distribution after oversampling: {class_counts_after_oversampling}")
         print(f"Training set number of samples: {len(dataset)}")
         return DataLoader(dataset, shuffle=shuffle, sampler=sampler,
                           batch_size=2, num_workers=8)
@@ -122,11 +117,16 @@ class ClassificationTask(pl.LightningModule, TFLogger):
         transformer.to_tensor()
         transforms = transformer.get_transforms()
         dataset = GeneralizedClassificationDataset(
-            dataset_path=self.dataset_path, split="val", 
+            dataset_path=self.dataset_path, 
+            split="val", 
             transforms=transforms, 
             classes=self.classes,
         )
         print(f"Validation set number of samples: {len(dataset)}")
+
+        labels = dataset.dataset['label'].tolist()
+        class_counts = {cls: labels.count(cls) for cls in set(labels)}
+        print(f"Validation set class distribution: {class_counts}")
         return DataLoader(dataset, shuffle=False,
                           batch_size=1, num_workers=8)
 

--- a/skingpt4/classification/classification_task.py
+++ b/skingpt4/classification/classification_task.py
@@ -111,7 +111,7 @@ class ClassificationTask(pl.LightningModule, TFLogger):
             shuffle = True
         print(f"Training set number of samples: {len(dataset)}")
         return DataLoader(dataset, shuffle=shuffle, sampler=sampler,
-                          batch_size=32, num_workers=8)
+                          batch_size=16, num_workers=8)
  
     def val_dataloader(self):
         transformer = Transformer()
@@ -129,7 +129,7 @@ class ClassificationTask(pl.LightningModule, TFLogger):
         class_counts = {cls: labels.count(cls) for cls in set(labels)}
         print(f"Validation set class distribution: {class_counts}")
         return DataLoader(dataset, shuffle=False,
-                          batch_size=32, num_workers=8)
+                          batch_size=1, num_workers=8)
 
     def test_dataloader(self):
         transformer = Transformer()
@@ -143,4 +143,4 @@ class ClassificationTask(pl.LightningModule, TFLogger):
         )
         print(f"Testing set number of samples: {len(dataset)}")
         return DataLoader(dataset, shuffle=False,
-                          batch_size=32, num_workers=8)
+                          batch_size=1, num_workers=8)

--- a/skingpt4/classification/classification_task.py
+++ b/skingpt4/classification/classification_task.py
@@ -20,6 +20,7 @@ class ClassificationTask(pl.LightningModule, TFLogger):
         self.evaluator = GeneralClassificationEvaluator()
         self.validation_outputs=[]
         self.lr = self.hparams.get('learning_rate', 5e-4)
+        self.val_batches = self.hparams.get('val_batches', 1.0)
         self.oversample = self.hparams.get('oversample', False)
         self.oversample_factor = self.hparams.get('oversample_factor', 1.0) 
         self.oversample_col = self.hparams.get('oversample_col', 'label')
@@ -125,7 +126,7 @@ class ClassificationTask(pl.LightningModule, TFLogger):
         )
         print(f"Validation set number of samples: {len(dataset)}")
         return DataLoader(dataset, shuffle=False,
-                          batch_size=8, num_workers=8)
+                          batch_size=self.val_batches, num_workers=8)
 
     def test_dataloader(self):
         transformer = Transformer()

--- a/skingpt4/classification/classification_task.py
+++ b/skingpt4/classification/classification_task.py
@@ -111,7 +111,7 @@ class ClassificationTask(pl.LightningModule, TFLogger):
             shuffle = True
         print(f"Training set number of samples: {len(dataset)}")
         return DataLoader(dataset, shuffle=shuffle, sampler=sampler,
-                          batch_size=32, num_workers=8)
+                          batch_size=2, num_workers=8)
  
     def val_dataloader(self):
         transformer = Transformer()
@@ -124,10 +124,6 @@ class ClassificationTask(pl.LightningModule, TFLogger):
             classes=self.classes,
         )
         print(f"Validation set number of samples: {len(dataset)}")
-
-        labels = dataset.dataset['label'].tolist()
-        class_counts = {cls: labels.count(cls) for cls in set(labels)}
-        print(f"Validation set class distribution: {class_counts}")
         return DataLoader(dataset, shuffle=False,
                           batch_size=1, num_workers=8)
 

--- a/skingpt4/classification/classification_task.py
+++ b/skingpt4/classification/classification_task.py
@@ -93,7 +93,8 @@ class ClassificationTask(pl.LightningModule, TFLogger):
         transformer.randomize_img(degree=1)
         transforms = transformer.get_transforms()
         dataset = GeneralizedClassificationDataset(
-            dataset_path=self.dataset_path, split="train", 
+            dataset_path=self.dataset_path, 
+            split="train", 
             transforms=transforms, 
             classes=self.classes, 
             data_regime=self.data_regime

--- a/skingpt4/classification/classification_task.py
+++ b/skingpt4/classification/classification_task.py
@@ -108,6 +108,11 @@ class ClassificationTask(pl.LightningModule, TFLogger):
         else:
             sampler = None
             shuffle = True
+
+        class_counts_after_oversampling = {cls: 0 for cls in set(labels)}
+        for idx in sampler:
+            class_counts_after_oversampling[labels[idx]] += 1
+        print(f"Class distribution after oversampling: {class_counts_after_oversampling}")
         print(f"Training set number of samples: {len(dataset)}")
         return DataLoader(dataset, shuffle=shuffle, sampler=sampler,
                           batch_size=2, num_workers=8)

--- a/skingpt4/classification/classification_task.py
+++ b/skingpt4/classification/classification_task.py
@@ -53,8 +53,6 @@ class ClassificationTask(pl.LightningModule, TFLogger):
         y_hat = (logits > 0).float()
         self.evaluator.update((logits, y))
         self.validation_outputs.append(loss)
-        print(f"Validation step batch: {batch}")
-        print(f"Val labels: {y}")
         return {'loss': loss}
 
     def on_validation_epoch_end(self):
@@ -113,7 +111,7 @@ class ClassificationTask(pl.LightningModule, TFLogger):
             shuffle = True
         print(f"Training set number of samples: {len(dataset)}")
         return DataLoader(dataset, shuffle=shuffle, sampler=sampler,
-                          batch_size=2, num_workers=8)
+                          batch_size=32, num_workers=8)
  
     def val_dataloader(self):
         transformer = Transformer()
@@ -131,7 +129,7 @@ class ClassificationTask(pl.LightningModule, TFLogger):
         class_counts = {cls: labels.count(cls) for cls in set(labels)}
         print(f"Validation set class distribution: {class_counts}")
         return DataLoader(dataset, shuffle=False,
-                          batch_size=1, num_workers=8)
+                          batch_size=32, num_workers=8)
 
     def test_dataloader(self):
         transformer = Transformer()
@@ -145,4 +143,4 @@ class ClassificationTask(pl.LightningModule, TFLogger):
         )
         print(f"Testing set number of samples: {len(dataset)}")
         return DataLoader(dataset, shuffle=False,
-                          batch_size=1, num_workers=8)
+                          batch_size=32, num_workers=8)


### PR DESCRIPTION
**Problem**
Previously, auroc metric would throw an error because validation data loader would only load one batch at a time; in rare exceptions it would run (60 and 70% confidence) but the warning was still appearing. 

**Solution**
This patch ensures consistent behavior for auroc across all the confidence subsets we're examining by enforcing a default validation batch size of 8; training also now supports customization of this parameter