### PR TITLE
fix: properly accomodate 2, 3, and 6 class classification

### DIFF
--- a/skingpt4/classification/metrics.py
+++ b/skingpt4/classification/metrics.py
@@ -52,24 +52,20 @@ def get_multiclass_metrics(probs, labels, num_classes):
         probs = probs[:, 1]
 
 
-    print(f"labels shape: {labels.shape}")
-    print(f"np.arange(num_classes) shape: {np.arange(num_classes).shape}")
+    
+    if not num_classes == 2:
+        labels = np.concatenate([labels, np.arange(num_classes)])
+        probs = np.vstack([probs, np.eye(num_classes)])
 
-    full_labels = np.concatenate([labels, np.arange(num_classes)])
-    full_probs = np.vstack([probs, np.eye(num_classes)])
-
-
-    print(f"full_labels shape: {full_labels.shape}")
-    print(f"full_probs shape: {full_probs.shape}")
 
     try:
-        auprc = average_precision_score(full_labels, full_probs, average='weighted')
+        auprc = average_precision_score(labels, probs, average='weighted')
     except ValueError:
         print("Invalid AUPRC calculation: check shape of labels and probs")
         auprc = float('nan') 
     
     try:
-        auroc = roc_auc_score(full_labels, full_probs, average='weighted', multi_class='ovr')
+        auroc = roc_auc_score(labels, probs, average='weighted', multi_class='ovr')
     except ValueError:
         print("Invalid AUPRC calculation: check shape of labels and probs")
         auroc = float('nan') 

--- a/skingpt4/classification/metrics.py
+++ b/skingpt4/classification/metrics.py
@@ -53,7 +53,7 @@ def get_multiclass_metrics(probs, labels, num_classes):
 
 
     
-    if not num_classes == 2:
+    if num_classes == 6:
         labels = np.concatenate([labels, np.arange(num_classes)])
         probs = np.vstack([probs, np.eye(num_classes)])
 

--- a/skingpt4/classification/metrics.py
+++ b/skingpt4/classification/metrics.py
@@ -51,8 +51,16 @@ def get_multiclass_metrics(probs, labels, num_classes):
     if probs.shape[1] == 2:
         probs = probs[:, 1]
 
+
+    print(f"labels shape: {labels.shape}")
+    print(f"np.arange(num_classes) shape: {np.arange(num_classes).shape}")
+
     full_labels = np.concatenate([labels, np.arange(num_classes)])
     full_probs = np.vstack([probs, np.eye(num_classes)])
+
+
+    print(f"full_labels shape: {full_labels.shape}")
+    print(f"full_probs shape: {full_probs.shape}")
 
     try:
         auprc = average_precision_score(full_labels, full_probs, average='weighted')


### PR DESCRIPTION
Some issues with AUPRC and AUROC when trying to do 2-class and 3-class classification; added a special case for 6 class classification problem